### PR TITLE
Adds support for Visual Studio 2022.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,9 @@ namespace VSKeyExtractor
 
             new Product("Visual Studio 2019 Enterprise"       , "41717607-F34E-432C-A138-A3CFD7E25CDA", "09260"),
             new Product("Visual Studio 2019 Professional"     , "41717607-F34E-432C-A138-A3CFD7E25CDA", "09262"),
+
+            new Product("Visual Studio 2022 Enterprise"       , "1299B4B9-DFCC-476D-98F0-F65A2B46C96D", "09660"),
+            new Product("Visual Studio 2022 Professional"     , "1299B4B9-DFCC-476D-98F0-F65A2B46C96D", "09662"),
         };
 
         static void Main()


### PR DESCRIPTION
The Microsoft Product Code (MPC) can be found [the official website](https://docs.microsoft.com/en-us/visualstudio/install/automatically-apply-product-keys-when-deploying-visual-studio?view=vs-2022). The key name is from my local installation.
Tested on Windows 10 1809.